### PR TITLE
fix: JSON formatting for Adverse Outcome state

### DIFF
--- a/parkinson_content.json
+++ b/parkinson_content.json
@@ -103,7 +103,7 @@
         },
         {
           "label": "Adverse Outcome",
-          "state":"disabled"
+          "state":"disabled",
           "value": "Adverse Outcome",
           "type": "process-flow-step"
         }


### PR DESCRIPTION
addresses #110